### PR TITLE
Fix 404 URLs with styled placeholder pages

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -32,6 +32,10 @@
   RewriteEngine On
   RewriteCond %{HTTPS} off
   RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+  # Redirect legacy hotel & tourism URLs missing the correct path
+  RewriteRule ^servicios/desarrollo-web-para-hoteles-y-turismo-en-guatemala/(.*)$ servicios/desarrollo-web-para-hoteles-y-turismo-en/$1 [L,R=301]
+  # Redirect older web development URLs that omit the /guatemala/ segment
+  RewriteRule ^servicios/desarrollo-web/((?!guatemala/).*)$ servicios/desarrollo-web/guatemala/$1 [L,R=301]
 </IfModule>
 
 # ===============================

--- a/live-previews/live-preview-lp-porter-ranch.html
+++ b/live-previews/live-preview-lp-porter-ranch.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es-GT">
+<head>
+  <link rel="apple-touch-icon" sizes="180x180" href="https://oscarleon.app/assets/favicon/favicon180x180.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://oscarleon.app/assets/favicon/favicon32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://oscarleon.app/assets/favicon/favicon16x16.png">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="author" content="OSCARLEON">
+  <meta name="theme-color" content="#01c27f">
+  <meta name="robots" content="index, follow">
+  <meta name="description" content="Vista previa de proyecto disponible en nuestro portafolio.">
+  <title>Live Preview</title>
+  <link rel="canonical" href="https://oscarleon.app/portafolio/portafolio-oscarleon.html">
+  <link rel="stylesheet" href="https://oscarleon.app/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a href="https://oscarleon.app/index.html" class="logo" aria-label="Ir a la página de inicio">OSCAR<span style="color: white;">LEON</span></a>
+      <div class="menu-toggle" onclick="toggleMenu()">☰</div>
+      <nav id="nav-menu">
+        <ul>
+          <li><a href="https://oscarleon.app/index.html" rel="noopener noreferrer">Inicio</a></li>
+          <li><a href="https://oscarleon.app/index.html#servicios-completos" rel="noopener noreferrer">Servicios</a></li>
+          <li><a href="https://oscarleon.app/clientes.html" rel="noopener noreferrer">Clientes</a></li>
+          <li><a href="https://oscarleon.app/certificaciones.html" rel="noopener noreferrer">Certificaciones</a></li>
+        </ul>
+      </nav>
+      <a href="https://wa.me/50212345678?text=Hola,%20quiero%20información" target="_blank" rel="noopener noreferrer" class="cta-login attention-animate">Contactar</a>
+    </div>
+  </header>
+  <main class="container">
+    <h1>Vista Previa</h1>
+    <p>Consulta la información completa en nuestro <a href="https://oscarleon.app/portafolio/portafolio-oscarleon.html">portafolio</a>.</p>
+  </main>
+  <script src="https://oscarleon.app/script.js"></script>
+</body>
+</html>

--- a/live-previews/live-preview-lp-porter-ranch.html#!
+++ b/live-previews/live-preview-lp-porter-ranch.html#!
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es-GT">
+<head>
+  <link rel="apple-touch-icon" sizes="180x180" href="https://oscarleon.app/assets/favicon/favicon180x180.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://oscarleon.app/assets/favicon/favicon32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://oscarleon.app/assets/favicon/favicon16x16.png">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="author" content="OSCARLEON">
+  <meta name="theme-color" content="#01c27f">
+  <meta name="robots" content="index, follow">
+  <meta name="description" content="Vista previa de proyecto disponible en nuestro portafolio.">
+  <title>Live Preview</title>
+  <link rel="canonical" href="https://oscarleon.app/portafolio/portafolio-oscarleon.html">
+  <link rel="stylesheet" href="https://oscarleon.app/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a href="https://oscarleon.app/index.html" class="logo" aria-label="Ir a la página de inicio">OSCAR<span style="color: white;">LEON</span></a>
+      <div class="menu-toggle" onclick="toggleMenu()">☰</div>
+      <nav id="nav-menu">
+        <ul>
+          <li><a href="https://oscarleon.app/index.html" rel="noopener noreferrer">Inicio</a></li>
+          <li><a href="https://oscarleon.app/index.html#servicios-completos" rel="noopener noreferrer">Servicios</a></li>
+          <li><a href="https://oscarleon.app/clientes.html" rel="noopener noreferrer">Clientes</a></li>
+          <li><a href="https://oscarleon.app/certificaciones.html" rel="noopener noreferrer">Certificaciones</a></li>
+        </ul>
+      </nav>
+      <a href="https://wa.me/50212345678?text=Hola,%20quiero%20información" target="_blank" rel="noopener noreferrer" class="cta-login attention-animate">Contactar</a>
+    </div>
+  </header>
+  <main class="container">
+    <h1>Vista Previa</h1>
+    <p>Consulta la información completa en nuestro <a href="https://oscarleon.app/portafolio/portafolio-oscarleon.html">portafolio</a>.</p>
+  </main>
+  <script src="https://oscarleon.app/script.js"></script>
+</body>
+</html>

--- a/live-previews/live-preview-nenas-escort.html
+++ b/live-previews/live-preview-nenas-escort.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es-GT">
+<head>
+  <link rel="apple-touch-icon" sizes="180x180" href="https://oscarleon.app/assets/favicon/favicon180x180.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://oscarleon.app/assets/favicon/favicon32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://oscarleon.app/assets/favicon/favicon16x16.png">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="author" content="OSCARLEON">
+  <meta name="theme-color" content="#01c27f">
+  <meta name="robots" content="index, follow">
+  <meta name="description" content="Vista previa de proyecto disponible en nuestro portafolio.">
+  <title>Live Preview</title>
+  <link rel="canonical" href="https://oscarleon.app/portafolio/portafolio-oscarleon.html">
+  <link rel="stylesheet" href="https://oscarleon.app/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a href="https://oscarleon.app/index.html" class="logo" aria-label="Ir a la página de inicio">OSCAR<span style="color: white;">LEON</span></a>
+      <div class="menu-toggle" onclick="toggleMenu()">☰</div>
+      <nav id="nav-menu">
+        <ul>
+          <li><a href="https://oscarleon.app/index.html" rel="noopener noreferrer">Inicio</a></li>
+          <li><a href="https://oscarleon.app/index.html#servicios-completos" rel="noopener noreferrer">Servicios</a></li>
+          <li><a href="https://oscarleon.app/clientes.html" rel="noopener noreferrer">Clientes</a></li>
+          <li><a href="https://oscarleon.app/certificaciones.html" rel="noopener noreferrer">Certificaciones</a></li>
+        </ul>
+      </nav>
+      <a href="https://wa.me/50212345678?text=Hola,%20quiero%20información" target="_blank" rel="noopener noreferrer" class="cta-login attention-animate">Contactar</a>
+    </div>
+  </header>
+  <main class="container">
+    <h1>Vista Previa</h1>
+    <p>Consulta la información completa en nuestro <a href="https://oscarleon.app/portafolio/portafolio-oscarleon.html">portafolio</a>.</p>
+  </main>
+  <script src="https://oscarleon.app/script.js"></script>
+</body>
+</html>

--- a/live-previews/live-preview-qr-generador.html
+++ b/live-previews/live-preview-qr-generador.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es-GT">
+<head>
+  <link rel="apple-touch-icon" sizes="180x180" href="https://oscarleon.app/assets/favicon/favicon180x180.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://oscarleon.app/assets/favicon/favicon32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://oscarleon.app/assets/favicon/favicon16x16.png">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="author" content="OSCARLEON">
+  <meta name="theme-color" content="#01c27f">
+  <meta name="robots" content="index, follow">
+  <meta name="description" content="Vista previa de proyecto disponible en nuestro portafolio.">
+  <title>Live Preview</title>
+  <link rel="canonical" href="https://oscarleon.app/portafolio/portafolio-oscarleon.html">
+  <link rel="stylesheet" href="https://oscarleon.app/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a href="https://oscarleon.app/index.html" class="logo" aria-label="Ir a la página de inicio">OSCAR<span style="color: white;">LEON</span></a>
+      <div class="menu-toggle" onclick="toggleMenu()">☰</div>
+      <nav id="nav-menu">
+        <ul>
+          <li><a href="https://oscarleon.app/index.html" rel="noopener noreferrer">Inicio</a></li>
+          <li><a href="https://oscarleon.app/index.html#servicios-completos" rel="noopener noreferrer">Servicios</a></li>
+          <li><a href="https://oscarleon.app/clientes.html" rel="noopener noreferrer">Clientes</a></li>
+          <li><a href="https://oscarleon.app/certificaciones.html" rel="noopener noreferrer">Certificaciones</a></li>
+        </ul>
+      </nav>
+      <a href="https://wa.me/50212345678?text=Hola,%20quiero%20información" target="_blank" rel="noopener noreferrer" class="cta-login attention-animate">Contactar</a>
+    </div>
+  </header>
+  <main class="container">
+    <h1>Vista Previa</h1>
+    <p>Consulta la información completa en nuestro <a href="https://oscarleon.app/portafolio/portafolio-oscarleon.html">portafolio</a>.</p>
+  </main>
+  <script src="https://oscarleon.app/script.js"></script>
+</body>
+</html>

--- a/live-previews/live-preview-qrliks.html
+++ b/live-previews/live-preview-qrliks.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es-GT">
+<head>
+  <link rel="apple-touch-icon" sizes="180x180" href="https://oscarleon.app/assets/favicon/favicon180x180.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://oscarleon.app/assets/favicon/favicon32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://oscarleon.app/assets/favicon/favicon16x16.png">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="author" content="OSCARLEON">
+  <meta name="theme-color" content="#01c27f">
+  <meta name="robots" content="index, follow">
+  <meta name="description" content="Vista previa de proyecto disponible en nuestro portafolio.">
+  <title>Live Preview</title>
+  <link rel="canonical" href="https://oscarleon.app/portafolio/portafolio-oscarleon.html">
+  <link rel="stylesheet" href="https://oscarleon.app/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a href="https://oscarleon.app/index.html" class="logo" aria-label="Ir a la página de inicio">OSCAR<span style="color: white;">LEON</span></a>
+      <div class="menu-toggle" onclick="toggleMenu()">☰</div>
+      <nav id="nav-menu">
+        <ul>
+          <li><a href="https://oscarleon.app/index.html" rel="noopener noreferrer">Inicio</a></li>
+          <li><a href="https://oscarleon.app/index.html#servicios-completos" rel="noopener noreferrer">Servicios</a></li>
+          <li><a href="https://oscarleon.app/clientes.html" rel="noopener noreferrer">Clientes</a></li>
+          <li><a href="https://oscarleon.app/certificaciones.html" rel="noopener noreferrer">Certificaciones</a></li>
+        </ul>
+      </nav>
+      <a href="https://wa.me/50212345678?text=Hola,%20quiero%20información" target="_blank" rel="noopener noreferrer" class="cta-login attention-animate">Contactar</a>
+    </div>
+  </header>
+  <main class="container">
+    <h1>Vista Previa</h1>
+    <p>Consulta la información completa en nuestro <a href="https://oscarleon.app/portafolio/portafolio-oscarleon.html">portafolio</a>.</p>
+  </main>
+  <script src="https://oscarleon.app/script.js"></script>
+</body>
+</html>

--- a/live-previews/live-preview-sexy-escort.html
+++ b/live-previews/live-preview-sexy-escort.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es-GT">
+<head>
+  <link rel="apple-touch-icon" sizes="180x180" href="https://oscarleon.app/assets/favicon/favicon180x180.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://oscarleon.app/assets/favicon/favicon32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://oscarleon.app/assets/favicon/favicon16x16.png">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="author" content="OSCARLEON">
+  <meta name="theme-color" content="#01c27f">
+  <meta name="robots" content="index, follow">
+  <meta name="description" content="Vista previa de proyecto disponible en nuestro portafolio.">
+  <title>Live Preview</title>
+  <link rel="canonical" href="https://oscarleon.app/portafolio/portafolio-oscarleon.html">
+  <link rel="stylesheet" href="https://oscarleon.app/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a href="https://oscarleon.app/index.html" class="logo" aria-label="Ir a la página de inicio">OSCAR<span style="color: white;">LEON</span></a>
+      <div class="menu-toggle" onclick="toggleMenu()">☰</div>
+      <nav id="nav-menu">
+        <ul>
+          <li><a href="https://oscarleon.app/index.html" rel="noopener noreferrer">Inicio</a></li>
+          <li><a href="https://oscarleon.app/index.html#servicios-completos" rel="noopener noreferrer">Servicios</a></li>
+          <li><a href="https://oscarleon.app/clientes.html" rel="noopener noreferrer">Clientes</a></li>
+          <li><a href="https://oscarleon.app/certificaciones.html" rel="noopener noreferrer">Certificaciones</a></li>
+        </ul>
+      </nav>
+      <a href="https://wa.me/50212345678?text=Hola,%20quiero%20información" target="_blank" rel="noopener noreferrer" class="cta-login attention-animate">Contactar</a>
+    </div>
+  </header>
+  <main class="container">
+    <h1>Vista Previa</h1>
+    <p>Consulta la información completa en nuestro <a href="https://oscarleon.app/portafolio/portafolio-oscarleon.html">portafolio</a>.</p>
+  </main>
+  <script src="https://oscarleon.app/script.js"></script>
+</body>
+</html>

--- a/servicios/desarrollo-web-para-hoteles-y-turismo-en-guatemala/guatemala/desarrollo-web-para-hoteles-y-turismo-en-guatemala-totonicapan.html
+++ b/servicios/desarrollo-web-para-hoteles-y-turismo-en-guatemala/guatemala/desarrollo-web-para-hoteles-y-turismo-en-guatemala-totonicapan.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es-GT">
+<head>
+  <link rel="apple-touch-icon" sizes="180x180" href="https://oscarleon.app/assets/favicon/favicon180x180.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://oscarleon.app/assets/favicon/favicon32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://oscarleon.app/assets/favicon/favicon16x16.png">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="author" content="OSCARLEON">
+  <meta name="theme-color" content="#01c27f">
+  <meta name="robots" content="index, follow">
+  <meta name="description" content="Página temporal para nuestro servicio de desarrollo web para hoteles y turismo en Totonicapán, Guatemala.">
+  <title>Desarrollo Web en Totonicapán | OSCARLEON</title>
+  <link rel="canonical" href="https://oscarleon.app/servicios/desarrollo-web-para-hoteles-y-turismo-en/guatemala/desarrollo-web-para-hoteles-y-turismo-en-totonicapan.html">
+  <link rel="stylesheet" href="https://oscarleon.app/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a href="https://oscarleon.app/index.html" class="logo" aria-label="Ir a la página de inicio">OSCAR<span style="color: white;">LEON</span></a>
+      <div class="menu-toggle" onclick="toggleMenu()">☰</div>
+      <nav id="nav-menu">
+        <ul>
+          <li><a href="https://oscarleon.app/index.html" rel="noopener noreferrer">Inicio</a></li>
+          <li><a href="https://oscarleon.app/index.html#servicios-completos" rel="noopener noreferrer">Servicios</a></li>
+          <li><a href="https://oscarleon.app/clientes.html" rel="noopener noreferrer">Clientes</a></li>
+          <li><a href="https://oscarleon.app/certificaciones.html" rel="noopener noreferrer">Certificaciones</a></li>
+        </ul>
+      </nav>
+      <a href="https://wa.me/50212345678?text=Hola,%20quiero%20información" target="_blank" rel="noopener noreferrer" class="cta-login attention-animate">Contactar</a>
+    </div>
+  </header>
+  <main class="container">
+    <h1>Desarrollo Web para Hoteles en Totonicapán</h1>
+    <p>Estamos actualizando esta dirección. Visita la versión más reciente de este servicio en <a href="https://oscarleon.app/servicios/desarrollo-web-para-hoteles-y-turismo-en/guatemala/desarrollo-web-para-hoteles-y-turismo-en-totonicapan.html">este enlace</a>.</p>
+  </main>
+  <script src="https://oscarleon.app/script.js"></script>
+</body>
+</html>

--- a/servicios/desarrollo-web-para-hoteles-y-turismo-en-guatemala/guatemala/peten/desarrollo-web-para-hoteles-y-turismo-en-guatemala-sayaxche.html
+++ b/servicios/desarrollo-web-para-hoteles-y-turismo-en-guatemala/guatemala/peten/desarrollo-web-para-hoteles-y-turismo-en-guatemala-sayaxche.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es-GT">
+<head>
+  <link rel="apple-touch-icon" sizes="180x180" href="https://oscarleon.app/assets/favicon/favicon180x180.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://oscarleon.app/assets/favicon/favicon32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://oscarleon.app/assets/favicon/favicon16x16.png">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="author" content="OSCARLEON">
+  <meta name="theme-color" content="#01c27f">
+  <meta name="robots" content="index, follow">
+  <meta name="description" content="Página temporal para nuestro servicio de desarrollo web para hoteles y turismo en Sayaxché, Petén.">
+  <title>Desarrollo Web en Sayaxché | OSCARLEON</title>
+  <link rel="canonical" href="https://oscarleon.app/servicios/desarrollo-web-para-hoteles-y-turismo-en/guatemala/peten/desarrollo-web-para-hoteles-y-turismo-en-sayaxche.html">
+  <link rel="stylesheet" href="https://oscarleon.app/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a href="https://oscarleon.app/index.html" class="logo" aria-label="Ir a la página de inicio">OSCAR<span style="color: white;">LEON</span></a>
+      <div class="menu-toggle" onclick="toggleMenu()">☰</div>
+      <nav id="nav-menu">
+        <ul>
+          <li><a href="https://oscarleon.app/index.html" rel="noopener noreferrer">Inicio</a></li>
+          <li><a href="https://oscarleon.app/index.html#servicios-completos" rel="noopener noreferrer">Servicios</a></li>
+          <li><a href="https://oscarleon.app/clientes.html" rel="noopener noreferrer">Clientes</a></li>
+          <li><a href="https://oscarleon.app/certificaciones.html" rel="noopener noreferrer">Certificaciones</a></li>
+        </ul>
+      </nav>
+      <a href="https://wa.me/50212345678?text=Hola,%20quiero%20información" target="_blank" rel="noopener noreferrer" class="cta-login attention-animate">Contactar</a>
+    </div>
+  </header>
+  <main class="container">
+    <h1>Desarrollo Web para Hoteles en Sayaxché</h1>
+    <p>Estamos actualizando esta dirección. Visita la versión más reciente de este servicio en <a href="https://oscarleon.app/servicios/desarrollo-web-para-hoteles-y-turismo-en/guatemala/peten/desarrollo-web-para-hoteles-y-turismo-en-sayaxche.html">este enlace</a>.</p>
+  </main>
+  <script src="https://oscarleon.app/script.js"></script>
+</body>
+</html>

--- a/servicios/desarrollo-web-para-hoteles-y-turismo-en-guatemala/guatemala/zacapa/desarrollo-web-para-hoteles-y-turismo-en-guatemala-san-jorge.html
+++ b/servicios/desarrollo-web-para-hoteles-y-turismo-en-guatemala/guatemala/zacapa/desarrollo-web-para-hoteles-y-turismo-en-guatemala-san-jorge.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es-GT">
+<head>
+  <link rel="apple-touch-icon" sizes="180x180" href="https://oscarleon.app/assets/favicon/favicon180x180.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://oscarleon.app/assets/favicon/favicon32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="https://oscarleon.app/assets/favicon/favicon16x16.png">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="author" content="OSCARLEON">
+  <meta name="theme-color" content="#01c27f">
+  <meta name="robots" content="index, follow">
+  <meta name="description" content="Página temporal para nuestro servicio de desarrollo web para hoteles y turismo en San Jorge, Zacapa.">
+  <title>Desarrollo Web en San Jorge | OSCARLEON</title>
+  <link rel="canonical" href="https://oscarleon.app/servicios/desarrollo-web-para-hoteles-y-turismo-en/guatemala/zacapa/desarrollo-web-para-hoteles-y-turismo-en-san-jorge.html">
+  <link rel="stylesheet" href="https://oscarleon.app/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a href="https://oscarleon.app/index.html" class="logo" aria-label="Ir a la página de inicio">OSCAR<span style="color: white;">LEON</span></a>
+      <div class="menu-toggle" onclick="toggleMenu()">☰</div>
+      <nav id="nav-menu">
+        <ul>
+          <li><a href="https://oscarleon.app/index.html" rel="noopener noreferrer">Inicio</a></li>
+          <li><a href="https://oscarleon.app/index.html#servicios-completos" rel="noopener noreferrer">Servicios</a></li>
+          <li><a href="https://oscarleon.app/clientes.html" rel="noopener noreferrer">Clientes</a></li>
+          <li><a href="https://oscarleon.app/certificaciones.html" rel="noopener noreferrer">Certificaciones</a></li>
+        </ul>
+      </nav>
+      <a href="https://wa.me/50212345678?text=Hola,%20quiero%20información" target="_blank" rel="noopener noreferrer" class="cta-login attention-animate">Contactar</a>
+    </div>
+  </header>
+  <main class="container">
+    <h1>Desarrollo Web para Hoteles en San Jorge</h1>
+    <p>Estamos actualizando esta dirección. Visita la versión más reciente de este servicio en <a href="https://oscarleon.app/servicios/desarrollo-web-para-hoteles-y-turismo-en/guatemala/zacapa/desarrollo-web-para-hoteles-y-turismo-en-san-jorge.html">este enlace</a>.</p>
+  </main>
+  <script src="https://oscarleon.app/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add temporary pages with basic site styles for several outdated service URLs
- create simple preview pages that link to the main portfolio

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6871c05fff5083229de9e601a492f95f