### PR TITLE
SEO cleanup: remove viewport duplicate and improve alt text

### DIFF
--- a/clientes.html
+++ b/clientes.html
@@ -104,32 +104,32 @@
         <!-- Reemplaza src con URLs reales de los logos de tus clientes -->
         <img
           src="assets-v4/img/logos-empresas-marcas/alcatel.svg"
-          alt="Logo Servicio 1"
+          alt="Logo de Alcatel"
           class="logo-cliente"
         />
         <img
           src="assets-v4/img/logos-empresas-marcas/gobierno-de-guatemala.svg"
-          alt="Logo Servicio 2"
+          alt="Logo del Gobierno de Guatemala"
           class="logo-cliente"
         />
         <img
           src="assets-v4/img/logos-empresas-marcas/local-plumbers.svg"
-          alt="Logo Servicio 3"
+          alt="Logo de Local Plumbers"
           class="logo-cliente"
         />
         <img
           src="assets-v4/img/logos-empresas-marcas/spectrum.svg"
-          alt="Logo Servicio 4"
+          alt="Logo de Spectrum"
           class="logo-cliente"
         />
         <img
           src="assets-v4/img/logos-empresas-marcas/malher-guatemala.svg"
-          alt="Logo Servicio 5"
+          alt="Logo de Malher Guatemala"
           class="logo-cliente"
         />
         <img
           src="assets-v4/img/logos-empresas-marcas/cepredenac.svg"
-          alt="Logo Servicio 6"
+          alt="Logo de CEPREDENAC"
           class="logo-cliente"
         />
       </div>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
 <meta http-equiv="X-XSS-Protection" content="1; mode=block">
 <meta name="referrer" content="strict-origin-when-cross-origin">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- Title -->
   <title>OSCARLEON | SEO, Desarrollo Web Profesional y Marketing Digital</title>


### PR DESCRIPTION
## Summary
- remove duplicate viewport meta tag from `index.html`
- add descriptive alt text for client logos in `clientes.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6872a4cdbb2c8322b6e4a9fc9f517242